### PR TITLE
Vagrant usage for automating VM provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,3 +14,38 @@ NUM_WORKER_NODES = 2
 IP_NW = "192.168.56"
 MASTER_IP_START = 11
 NODE_IP_START = 20
+
+# Host operating sysem detection
+module OS
+  def OS.windows?
+    (/cygwin|mswin|mingw|bccwin|wince|emx/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.mac?
+    (/darwin/ =~ RUBY_PLATFORM) != nil
+  end
+
+  def OS.unix?
+    !OS.windows?
+  end
+
+  def OS.linux?
+    OS.unix? and not OS.mac?
+  end
+
+  def OS.jruby?
+    RUBY_ENGINE == "jruby"
+  end
+end
+
+# Determine host adpater for bridging in BRIDGE mode
+def get_bridge_adapter()
+  if OS.windows?
+    return %x{powershell -Command "Get-NetRoute -DestinationPrefix 0.0.0.0/0 | Get-NetAdapter | Select-Object -ExpandProperty InterfaceDescription"}.chomp
+  elsif OS.linux?
+    return %x{ip route | grep default | awk '{ print $5 }'}.chomp
+  elsif OS.mac?
+    return %x{mac/mac-bridge.sh}.chomp
+  end
+end
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -112,4 +112,23 @@ Vagrant.configure("2") do |config|
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.
   config.vm.box_check_update = false
+
+  # Provision Master Nodes
+  config.vm.define "controlplane" do |node|
+    # Name shown in the GUI
+    node.vm.provider "virtualbox" do |vb|
+      vb.name = "controlplane"
+      vb.memory = 2048
+      vb.cpus = 2
+    end
+    node.vm.hostname = "controlplane"
+    if BUILD_MODE == "BRIDGE"
+      adapter = ""
+      node.vm.network :public_network, bridge: get_bridge_adapter()
+    else
+      node.vm.network :private_network, ip: IP_NW + ".#{MASTER_IP_START}"
+      node.vm.network "forwarded_port", guest: 22, host: "#{2710}"
+    end
+    provision_kubernetes_node node
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -131,4 +131,23 @@ Vagrant.configure("2") do |config|
     end
     provision_kubernetes_node node
   end
+
+  # Provision Worker Nodes
+  (1..NUM_WORKER_NODES).each do |i|
+    config.vm.define "node0#{i}" do |node|
+      node.vm.provider "virtualbox" do |vb|
+        vb.name = "node0#{i}"
+        vb.memory = 1024
+        vb.cpus = 1
+      end
+      node.vm.hostname = "node0#{i}"
+      if BUILD_MODE == "BRIDGE"
+        node.vm.network :public_network, bridge: get_bridge_adapter()
+      else
+        node.vm.network :private_network, ip: IP_NW + ".#{NODE_IP_START + i}"
+        node.vm.network "forwarded_port", guest: 22, host: "#{2720 + i}"
+      end
+      provision_kubernetes_node node
+    end
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -92,3 +92,24 @@ def provision_kubernetes_node(node)
   # Set up ssh
   node.vm.provision "setup-ssh", :type => "shell", :path => "ubuntu/ssh.sh"
 end
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  # config.vm.box = "base"
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.boot_timeout = 900
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,3 +74,21 @@ def all_nodes_up()
   end
   return true
 end
+
+# Sets up hosts file and DNS
+def setup_dns(node)
+  # Set up /etc/hosts
+  node.vm.provision "setup-hosts", :type => "shell", :path => "vagrant/setup-hosts.sh" do |s|
+    s.args = [IP_NW, BUILD_MODE, NUM_WORKER_NODES, MASTER_IP_START, NODE_IP_START]
+  end
+  # Set up DNS resolution
+  node.vm.provision "setup-dns", type: "shell", :path => "ubuntu/update-dns.sh"
+end
+
+# Runs provisioning steps that are required by masters and workers
+def provision_kubernetes_node(node)
+  # Set up DNS
+  setup_dns node
+  # Set up ssh
+  node.vm.provision "setup-ssh", :type => "shell", :path => "ubuntu/ssh.sh"
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -49,3 +49,28 @@ def get_bridge_adapter()
   end
 end
 
+# Helper method to get the machine ID of a node.
+# This will only be present if the node has been
+# created in VirtualBox.
+def get_machine_id(vm_name)
+  machine_id_filepath = ".vagrant/machines/#{vm_name}/virtualbox/id"
+  if not File.exist? machine_id_filepath
+    return nil
+  else
+    return File.read(machine_id_filepath)
+  end
+end
+
+# Helper method to determine whether all nodes are up
+def all_nodes_up()
+  if get_machine_id("controlplane").nil?
+    return false
+  end
+
+  (1..NUM_WORKER_NODES).each do |i|
+    if get_machine_id("node0#{i}").nil?
+      return false
+    end
+  end
+  return true
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,16 @@
+# Set the build mode
+# "BRIDGE" - Places VMs on your local network so cluster can be accessed from browser.
+#            You must have enough spare IPs on your network for the cluster nodes.
+# "NAT"    - Places VMs in a private virtual network. Cluster cannot be accessed
+#            without setting up a port forwarding rule for every NodePort exposed.
+#            Use this mode if for some reason BRIDGE doesn't work for you.
+BUILD_MODE = "BRIDGE"
+
+# Define the number of worker nodes
+# If this number is changed, remember to update setup-hosts.sh script with the new hosts IP details in /etc/hosts of each VM.
+NUM_WORKER_NODES = 2
+
+# Network parameters for NAT mode
+IP_NW = "192.168.56"
+MASTER_IP_START = 11
+NODE_IP_START = 20

--- a/ubuntu/ssh.sh
+++ b/ubuntu/ssh.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Enable password auth in sshd so we can use ssh-copy-id
+sed -i 's/#PasswordAuthentication/PasswordAuthentication/' /etc/ssh/sshd_config
+sed -i 's/KbdInteractiveAuthentication no/KbdInteractiveAuthentication yes/' /etc/ssh/sshd_config
+systemctl restart sshd

--- a/ubuntu/update-dns.sh
+++ b/ubuntu/update-dns.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Point to Google's DNS server
+sed -i -e 's/#DNS=/DNS=8.8.8.8/' /etc/systemd/resolved.conf
+
+service systemd-resolved restart

--- a/vagrant/setup-hosts.sh
+++ b/vagrant/setup-hosts.sh
@@ -41,3 +41,10 @@ echo "PRIMARY_IP=${MY_IP}" >> /etc/environment
 
 [ "$BUILD_MODE" = "BRIDGE" ] && exit 0
 
+# Update /etc/hosts about other hosts (NAT mode)
+echo "${MY_NETWORK}.${MASTER_IP_START} controlplane" >> /etc//hosts
+for i in $(seq 1 $NUM_WORKER_NODES)
+do
+    num=$(( $NODE_IP_START + $i ))
+    echo "${MY_NETWORK}.${num} node0${i}" >> /etc//hosts
+done

--- a/vagrant/setup-hosts.sh
+++ b/vagrant/setup-hosts.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Set up /etc/hosts so we can resolve all the nodes
+
+set -e
+
+IP_NW=$1
+BUILD_MODE=$2
+NUM_WORKER_NODES=$3
+MASTER_IP_START=$4
+NODE_IP_START=$5
+
+if [ "$BUILD_MODE" = "BRIDGE" ]
+then
+    # Determine machine IP from route table -
+    # Interface that routes to default GW that isn't on the NAT network.
+    MY_IP="$(ip route | grep default | grep -Pv '10\.\d+\.\d+\.\d+' | awk '{ print $9 }')"
+
+    # From this, determine the network (which for average broadband we assume is a /24)
+    MY_NETWORK=$(echo $MY_IP | awk 'BEGIN {FS="."} ; { printf("%s.%s.%s", $1, $2, $3) }')
+
+    # Create a script that will return this machine's IP to the bridge post-provisioner.
+    cat <<EOF > /usr/local/bin/public-ip
+#!/usr/bin/env sh
+echo -n $MY_IP
+EOF
+    chmod +x /usr/local/bin/public-ip
+else
+    # Determine machine IP from route table -
+    # Interface that is connected to the NAT network.
+    MY_IP="$(ip route | grep "^$IP_NW" | awk '{print $NF}')"
+    MY_NETWORK=$IP_NW
+fi
+
+# Remove unwanted entries
+sed -e '/^.*ubuntu-jammy.*/d' -i /etc/hosts
+sed -e "/^.*${HOSTNAME}.*/d" -i /etc/hosts
+
+# Export PRIMARY IP as an environment variable
+echo "PRIMARY_IP=${MY_IP}" >> /etc/environment
+
+[ "$BUILD_MODE" = "BRIDGE" ] && exit 0
+


### PR DESCRIPTION
Easily spawn the Kubernetes cluster on virtual machines with Vagrant.

Ensuring full network connectivity between all machines in the cluster.